### PR TITLE
Fix: NPCs walking over objects (chests, tables, chairs, etc.) (#2425)

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -102,7 +102,7 @@ void Npc::reset()
 	pushable = true;
 	floorChange = false;
 	attackable = false;
-	ignoreHeight = true;
+	ignoreHeight = false;
 	focusCreature = 0;
 	speechBubble = SPEECHBUBBLE_NONE;
 


### PR DESCRIPTION
Fixes the NPCs walking over objects (chests, tables, chairs, etc.) thx @henriquesameshima .

Before the attribute ignoreHeight was setted to true by default, wich made the NPCs ignore the difference in height by those said items, therefore making them walking over it.