### PR TITLE
Fix: Supply Stash (crash/hireling) (#2448)

### DIFF
--- a/data/npc/scripts/hireling.lua
+++ b/data/npc/scripts/hireling.lua
@@ -1034,7 +1034,7 @@ local function creatureSayCallback(cid, type, msg)
 		elseif msgcontains(msg, "stash") then
 			if hireling:hasSkill(HIRELING_SKILLS.STEWARD) then
 				npcHandler:say(GREETINGS.STASH, cid)
-				player:OpenStash()
+				player:openStash(true)
 			else
 				sendSkillNotLearned(cid, HIRELING_SKILLS.STEWARD)
 			end

--- a/data/scripts/movements/others/tiles.lua
+++ b/data/scripts/movements/others/tiles.lua
@@ -38,7 +38,7 @@ function tiles.onStepIn(creature, item, position, fromPosition)
 
 			player:sendTextMessage(MESSAGE_FAILURE, "Your depot contains " .. depotItems .. " item" .. (depotItems > 1 and "s." or ".") .. "\
 			Your supply stash contains " .. player:getStashCount() .. " item" .. (player:getStashCount()	 > 1 and "s." or "."))
-			player:setSpecialContainersAvailable(true)
+			player:setSpecialContainersAvailable(true, true)
 			return true
 		end
 	end
@@ -72,7 +72,7 @@ function tiles.onStepOut(creature, item, position, fromPosition)
 	end
 
 	item:transform(decreasing[item.itemid])
-	player:setSpecialContainersAvailable(false)
+	player:setSpecialContainersAvailable(false, false)
 	return true
 end
 

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -120,6 +120,24 @@ void Container::addItem(Item* item)
 	item->setParent(this);
 }
 
+StashContainerList Container::getStowableItems() const
+{
+	StashContainerList toReturnList;
+	for (auto item : itemlist) {
+		if (item->getContainer() != NULL) {
+			auto subContainer = item->getContainer()->getStowableItems();
+			for (auto subContItem : subContainer) {
+				Item* containerItem = subContItem.first;
+				toReturnList.push_back(std::pair<Item*, uint32_t>(containerItem, static_cast<uint32_t>(containerItem->getItemCount())));
+			}
+		} else if (item->isItemStorable()) {
+			toReturnList.push_back(std::pair<Item*, uint32_t>(item, static_cast<uint32_t>(item->getItemCount())));
+		}
+	}
+
+	return toReturnList;
+}
+
 Attr_ReadValue Container::readAttr(AttrTypes_t attr, PropStream& propStream)
 {
 	if (attr == ATTR_CONTAINER_ITEMS) {

--- a/src/container.h
+++ b/src/container.h
@@ -119,6 +119,7 @@ class Container : public Item, public Cylinder
 
 		bool hasParent() const;
 		void addItem(Item* item);
+		StashContainerList getStowableItems() const;
 		Item* getItemByIndex(size_t index) const;
 		bool isHoldingItem(const Item* item) const;
 

--- a/src/enums.h
+++ b/src/enums.h
@@ -821,7 +821,6 @@ struct CombatDamage
 	}
 };
 
-using StashContainerList = std::map<uint16_t, std::pair<bool, uint32_t>>;
 using StashItemList = std::map<uint16_t, uint32_t>;
 using MarketOfferList = std::list<MarketOffer>;
 using HistoryMarketOfferList = std::list<HistoryMarketOffer>;

--- a/src/game.h
+++ b/src/game.h
@@ -390,10 +390,7 @@ class Game
 		void playerOpenChannel(uint32_t playerId, uint16_t channelId);
 		void playerCloseChannel(uint32_t playerId, uint16_t channelId);
 		void playerOpenPrivateChannel(uint32_t playerId, std::string& receiver);
-		void playerStowItem(Player* player, Item* item, uint32_t count);
-		void playerStowItem(Player* player, const Position& pos, uint16_t spriteId, uint8_t stackpos, uint32_t count);
-		void playerStowContainer(Player* player, const Position& pos, uint16_t spriteId, uint8_t stackpos);
-		void playerStowAllItems(Player* player, const Position& pos, uint16_t spriteId, uint8_t stackpos);
+		void playerStowItem(Player* player, const Position& pos, uint16_t spriteId, uint8_t stackpos, uint8_t count, bool allItems);
 		void playerStashWithdraw(Player* player, uint16_t spriteId, uint32_t count, uint8_t stackpos);
 		void playerCloseNpcChannel(uint32_t playerId);
 		void playerReceivePing(uint32_t playerId);

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -382,6 +382,12 @@ Player* Item::getHoldingPlayer() const
 	return nullptr;
 }
 
+bool Item::isItemStorable() const
+{
+	auto isContainerAndHasSomethingInside = (getContainer() != NULL) && (getContainer()->getItemList().size() > 0);
+	return (isStowable() || isContainerAndHasSomethingInside);
+}
+
 void Item::setSubType(uint16_t n)
 {
 	const ItemType& it = items[id];

--- a/src/item.h
+++ b/src/item.h
@@ -1005,6 +1005,7 @@ class Item : virtual public Thing
 
 		void setDefaultSubtype();
 		uint16_t getSubType() const;
+		bool isItemStorable() const;
 		void setSubType(uint16_t n);
 
 		void setUniqueId(uint16_t n);
@@ -1092,5 +1093,6 @@ class Item : virtual public Thing
 
 using ItemList = std::list<Item*>;
 using ItemDeque = std::deque<Item*>;
+using StashContainerList = std::vector<std::pair<Item*, uint32_t>>;
 
 #endif

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -9838,13 +9838,16 @@ int LuaScriptInterface::luaPlayerSetOfflineTrainingSkill(lua_State* L)
 
 int LuaScriptInterface::luaPlayerOpenStash(lua_State* L)
 {
-	// player:openStash()
+	// player:openStash(isNpc)
 	Player* player = getUserdata<Player>(L, 1);
-	if (!player) {
-		return 1;
+	bool isNpc = getBoolean(L, 2, false);
+	if (player) {
+		player->sendOpenStash(isNpc);
+		pushBoolean(L, true);
+	} else {
+		lua_pushnil(L);
 	}
 
-	player->sendOpenStash();
 	return 1;
 }
 
@@ -10163,12 +10166,12 @@ int LuaScriptInterface::luaPlayerSetGroup(lua_State* L)
 
 int LuaScriptInterface::luaPlayerSetSpecialContainersAvailable(lua_State* L)
 {
-	// player:setSpecialContainersAvailable(supplyStashAvailable)
-	bool supplyStashAvailable = getBoolean(L, 2);
+	// player:setSpecialContainersAvailable(stashMenu, marketMenu)
+	bool supplyStashMenu = getBoolean(L, 2, false);
+	bool marketMenu = getBoolean(L, 3, false);
 	Player* player = getUserdata<Player>(L, 1);
 	if (player) {
-		player->setSupplyStashAvailable(supplyStashAvailable);
-		player->sendSpecialContainersAvailable(supplyStashAvailable);
+		player->setSpecialMenuAvailable(supplyStashMenu, marketMenu);
 		pushBoolean(L, true);
 	} else {
 		lua_pushnil(L);

--- a/src/player.h
+++ b/src/player.h
@@ -526,8 +526,20 @@ class Player final : public Creature, public Cylinder
 		bool isInMarket() const {
 			return inMarket;
 		}
-		void setSupplyStashAvailable(bool value) {
-			supplyStashAvailable = value;
+		void setSpecialMenuAvailable(bool supplyStashBool, bool marketMenuBool) {
+			// Menu option 'stow, stow container ...'
+			// Menu option 'show in market'
+			supplyStash = supplyStashBool;
+			marketMenu = marketMenuBool;
+			if (client) {
+				client->sendSpecialContainersAvailable();
+			}
+		}
+		bool isSupplyStashMenuAvailable() {
+			return supplyStash;
+		}
+		bool isMarketMenuAvailable() {
+			return marketMenu;
 		}
 		bool isExerciseTraining() {
 			return exerciseTraining;
@@ -630,7 +642,6 @@ class Player final : public Creature, public Cylinder
 		void addMessageBuffer();
 		void removeMessageBuffer();
 
-		bool removeItemClientId(uint16_t clientId, uint32_t count) const;
 		bool removeItemOfType(uint16_t itemId, uint32_t amount, int32_t subType, bool ignoreEquipped = false) const;
 
 		void addItemOnStash(uint16_t clientId, uint32_t amount) {
@@ -824,7 +835,7 @@ class Player final : public Creature, public Cylinder
 
 		//stash functions
 		bool addItemFromStash(uint16_t itemId, uint32_t itemCount);
-		void stowContainer(Item* item, uint32_t count);
+		void stowItem(Item* item, uint32_t count, bool allItems);
 
 		void changeHealth(int32_t healthChange, bool sendHealthChange = true) override;
 		void changeMana(int32_t manaChange) override;
@@ -1388,11 +1399,6 @@ class Player final : public Creature, public Cylinder
 				client->sendChannelsDialog();
 			}
 		}
-		void sendSpecialContainersAvailable(bool supplyStashAvailable) {
-			if (client) {
-				client->sendSpecialContainersAvailable(supplyStashAvailable);
-			}
-		}
 		void sendOpenPrivateChannel(const std::string& receiver) {
 			if (client) {
 				client->sendOpenPrivateChannel(receiver);
@@ -1550,10 +1556,14 @@ class Player final : public Creature, public Cylinder
 			lastPong = OTSYS_TIME();
 		}
 
-		void sendOpenStash() {
-			if (client && getLastDepotId() != -1) {
+		void sendOpenStash(bool isNpc = false) {
+			if (client && ((getLastDepotId() != -1) || isNpc)) {
         		client->sendOpenStash();
 			}
+		}
+		bool isStashExhausted() const;
+		void updateStashExhausted() {
+			lastStashInteraction = OTSYS_TIME();
 		}
 
 		void onThink(uint32_t interval) override;
@@ -1877,9 +1887,6 @@ class Player final : public Creature, public Cylinder
 
 		void updateInventoryWeight();
 
-		bool isItemStorable(Item* item);
-		ItemDeque getAllStorableItemsInContainer(Item* container);
-
 		void setNextWalkActionTask(SchedulerTask* task);
 		void setNextWalkTask(SchedulerTask* task);
 		void setNextActionTask(SchedulerTask* task, bool resetIdleTime = true);
@@ -1971,6 +1978,7 @@ class Player final : public Creature, public Cylinder
 		int64_t lastWalkthroughAttempt = 0;
 		int64_t lastToggleMount = 0;
 		int64_t lastMarketInteraction = 0;  //Custom: Anti bug do market
+		int64_t lastStashInteraction = 0;
 		int64_t lastPing;
 		int64_t lastPong;
 		int64_t nextAction = 0;
@@ -2117,7 +2125,8 @@ class Player final : public Creature, public Cylinder
 		bool logged = false;
 		bool scheduledSaleUpdate = false;
 		bool inEventMovePush = false;
-		bool supplyStashAvailable = false;
+		bool supplyStash = false; // Menu option 'stow, stow container ...'
+		bool marketMenu = false; // Menu option 'show in market'
 		bool exerciseTraining = false;
 
 		static uint32_t playerAutoID;

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -473,9 +473,8 @@ private:
 	void sendInventory();
 
 	void sendOpenStash();
-	void AddPlayerStowedItems(NetworkMessage &msg);
 	void parseStashWithdraw(NetworkMessage &msg);
-	void sendSpecialContainersAvailable(bool supplyStashAvailable);
+	void sendSpecialContainersAvailable();
 };
 
 #endif


### PR DESCRIPTION
* Resolves #2441, Resolves #2384
- Fix stash crashs, hireling errors and improving supply stash system.
- Added a exaust on supply stash actions. (Prevent exploits)
- Added 'show in market' option on menu. (When a player step on depot tile the option 'show in market' will be on the item menu)